### PR TITLE
Fixed typo in alerts required.

### DIFF
--- a/forecast.io/forecast.json
+++ b/forecast.io/forecast.json
@@ -37,7 +37,7 @@
         },
         "alerts" : {
             "type" : "array",
-            "required" : "false",
+            "required" : false,
             "items" : {
                 "type" : "object",
                 "properties" : {


### PR DESCRIPTION
forecast.json has typo in alerts required.